### PR TITLE
CRW-2998 the CHE_NAMESPACE and the...

### DIFF
--- a/build/scripts/sync.sh
+++ b/build/scripts/sync.sh
@@ -123,7 +123,9 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|(const DEFAULT_CHE_OPERATOR_SUBSCRIPTION_NAME =).+|\1 'devspaces-subscription'|g" \
 			-e "s|(const OPERATOR_GROUP_NAME =).+|\1 'devspaces-operator-group'|g" \
 			-e "s|(const OPENSHIFT_OLM_CATALOG =).+|\1 'redhat-operators'|g" \
-			-e "s|(const DEFAULT_OLM_SUGGESTED_NAMESPACE =).+|\1 'openshift-operators'|g" \
+			`# CRW-2998 the CHE_NAMESPACE and the OLM_SUGGESTED_NAMESPACE should BOTH be set to something other than openshift-operators` \
+			`# this does not change the namespace used for the operator subscription... just the cheCluster and deployed pods` \
+			-e "s|(const DEFAULT_OLM_SUGGESTED_NAMESPACE =).+|\1 'openshift-devspaces'|g" \
 			-e "s|(const DEFAULT_CHE_NAMESPACE =).+|\1 'openshift-devspaces'|g" \
 			-e "s|(const LEGACY_CHE_NAMESPACE =).+|\1 'openshift-workspaces'|g" \
 			-e "s|(CVS_PREFIX =).+|\1 'devspacesoperator'|g" \

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,7 +62,7 @@ export const CUSTOM_CATALOG_SOURCE_NAME = 'devspaces-custom-catalog-source'
 export const NEXT_CATALOG_SOURCE_NAME = 'eclipse-che-preview'
 export const NEXT_CATALOG_SOURCE_DEV_WORKSPACE_OPERATOR = 'custom-devworkspace-operator-catalog'
 export const STABLE_CATALOG_SOURCE_DEV_WORKSPACE_OPERATOR = 'stable-custom-devworkspace-operator-catalog'
-export const DEFAULT_OLM_SUGGESTED_NAMESPACE = 'openshift-operators'
+export const DEFAULT_OLM_SUGGESTED_NAMESPACE = 'openshift-devspaces'
 export const KUBERNETES_OLM_CATALOG = 'operatorhubio-catalog'
 export const OPENSHIFT_OLM_CATALOG = 'redhat-operators'
 


### PR DESCRIPTION
### What does this PR do?

CRW-2998 the CHE_NAMESPACE and the OLM_SUGGESTED_NAMESPACE should BOTH be set to something other than openshift-operators; this does not change the namespace used for the operator subscription... just the cheCluster and deployed pods

Change-Id: Ie254aca2a176fb1e827c81b5b61b49e3a7f59c96
Signed-off-by: Nick Boldt <nickboldt@gmail.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.