### PR TITLE
fix: CRW-3021 - remove checks for server and...

### DIFF
--- a/build/scripts/sync.sh
+++ b/build/scripts/sync.sh
@@ -22,8 +22,6 @@ usage () {
 	echo "Example: $0 -b ${MIDSTM_BRANCH} -s /absolute/path/to/chectl -t /absolute/path/to/dsc"
 	echo ""
 	echo "Options:
-	--server-tag ${DEFAULT_TAG}-xx   (instead of default ${DEFAULT_TAG})
-	--operator-tag ${DEFAULT_TAG}-yy (instead of default ${DEFAULT_TAG})
 	--crw-version ${DEFAULT_TAG}     (compute from MIDSTM_BRANCH if not set)
 	"
 	exit 1
@@ -37,8 +35,6 @@ while [[ "$#" -gt 0 ]]; do
 	'-t') TARGETDIR="$2"; TARGETDIR="${TARGETDIR%/}"; shift 1;;
 	'--help'|'-h') usage;;
 	# optional tag overrides
-	'--server-tag') CRW_SERVER_TAG="$2"; shift 1;;
-	'--operator-tag') CRW_OPERATOR_TAG="$2"; shift 1;;
 	'--crw-version') CRW_VERSION="$2"; DEFAULT_TAG="$2"; shift 1;;
   esac
   shift 1
@@ -47,10 +43,7 @@ done
 if [[ ! -d "${SOURCEDIR}" ]]; then usage; fi
 if [[ -z "${TARGETDIR}" ]] || [[ ${TARGETDIR} == "." ]]; then usage; else mkdir -p "${TARGETDIR}"; fi
 
-# TODO can we just remove all these CRW_*_TAG values? if they're only for operator mode (OCP 3.11) then surely they're no longer needed?
 # if not set use crw-3.y-rhel-8 ==> 3.y as the default tag
-if [[ -z "${CRW_SERVER_TAG}" ]];   then CRW_SERVER_TAG=${MIDSTM_BRANCH#*-};   CRW_SERVER_TAG=${CRW_SERVER_TAG%%-*};     fi
-if [[ -z "${CRW_OPERATOR_TAG}" ]]; then CRW_OPERATOR_TAG=${MIDSTM_BRANCH#*-}; CRW_OPERATOR_TAG=${CRW_OPERATOR_TAG%%-*}; fi
 if [[ -z "${CRW_VERSION}" ]];      then CRW_VERSION=${MIDSTM_BRANCH#*-};      CRW_VERSION=${CRW_VERSION%%-*};           fi
 
 # ignore changes in these files


### PR DESCRIPTION
### What does this PR do?

fix: CRW-3021 - remove checks for server and operator tags as we don't use operator-install mode anymore in 3.0 (only olm mode)

Change-Id: I94da07917fe531916bac435c1f077d059edd16b2
Signed-off-by: Nick Boldt <nickboldt@gmail.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.