### PR TITLE
CRW-4128 remove trailing slack from...

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -133,7 +133,7 @@ fi
 # RENAME artifacts to include version in the tarball: devspaces-3.0.0-dsc-*.tar.gz
 # do not include SHA1 so that the tar can be used in QE CI processes without wildcard
 TARBALL_PREFIX="devspaces-${CSV_VERSION}"
-TODAY_DIR="${WORKSPACE}/${TARBALL_PREFIX}.${today}/"
+TODAY_DIR="${WORKSPACE}/${TARBALL_PREFIX}.${today}"
 
 # compute latest tags for server and operator from quay; also set prerelease=false for GA
 repoFlag="--quay"


### PR DESCRIPTION
### What does this PR do?

CRW-4128 remove trailing slack from TODAY_DIR so rsync creates it on remote

Change-Id: I348b7ed087b675b2e748957752fd01ea2a8d61e0
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.