### PR TITLE
chore: add a 4th reusable tag: 3.yy.z-CI...

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -205,8 +205,8 @@ if [[ $PUBLISH_TO_QUAY -eq 1 ]]; then
     ########################################################################
     echo "[INFO] 4. Publish containers (with tarballs and sources) to Quay"
     ########################################################################
-    # copy container to quay under 3 tags
-    tags="${DSC_TAG} ${DS_VERSION}"
+    # copy container to quay under 4 tags: 3.10.0-CI-SHA1, 3.10.0-CI, 3.10, next/latest
+    tags="${DSC_TAG} ${DSC_TAG%-*} ${DS_VERSION}"
     if [[ $MIDSTM_BRANCH == "devspaces-3-rhel-8" ]]; then
         tags="$tags next"
     elif [[ $MIDSTM_BRANCH == "devspaces-3."*"-rhel-8" ]]; then


### PR DESCRIPTION
### What does this PR do?

chore: add a 4th reusable tag: 3.yy.z-CI (CRW-4855)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.